### PR TITLE
updating service trait to use async_trait instead of impl Future

### DIFF
--- a/changelogs/185711254-add-service-type.md
+++ b/changelogs/185711254-add-service-type.md
@@ -1,0 +1,3 @@
+- [186811254](https://www.pivotaltracker.com/story/show/186811254) - update service trait to use async_trait
+    - updates Service trait to use async_trait instead of impl Future
+

--- a/oxidauth-kernel/src/service.rs
+++ b/oxidauth-kernel/src/service.rs
@@ -8,10 +8,9 @@ pub trait Service<Request>: Send + Sync + 'static {
     type Response;
     type Error;
 
-    fn call(
-        &self,
-        req: Request,
-    ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send;
+    async fn call(&self, req: Request) -> Result<Self::Response, Self::Error>
+    where
+        Request: 'async_trait;
 }
 
 pub trait Layer<S> {
@@ -48,6 +47,7 @@ pub struct CanService<'a, S> {
     service: S,
 }
 
+#[async_trait]
 impl<S, Request> Service<Request> for CanService<'static, S>
 where
     S: Service<Request>,
@@ -89,6 +89,7 @@ mod tests {
     pub struct MockService;
     pub struct MockServiceParams(&'static str);
 
+    #[async_trait]
     impl Service<MockServiceParams> for MockService {
         type Response = ();
         type Error = ();

--- a/oxidauth-postgres/src/users/insert_user/mod.rs
+++ b/oxidauth-postgres/src/users/insert_user/mod.rs
@@ -5,6 +5,7 @@ use crate::Database;
 
 use super::{TryFromUserRowError, UserRow};
 
+#[async_trait]
 impl<'a> Service<&'a InsertUserParams> for Database {
     type Response = User;
 

--- a/oxidauth-usecases/src/authorities/register.rs
+++ b/oxidauth-usecases/src/authorities/register.rs
@@ -38,6 +38,7 @@ where
     }
 }
 
+#[async_trait]
 impl<A, U, UA, P> Service<P> for RegisterUseCase<A, U, UA>
 where
     A: FindAuthorityByClientIdService,


### PR DESCRIPTION
Ticket: [186811254](https://www.pivotaltracker.com/story/show/186811254)

# Summary 
updates Service trait to use async_trait instead of impl Future
fixes a few cases where #[async_trait] was not used and needed to be after the update.