### PR TITLE
187415087 - list users by ids

### DIFF
--- a/changelogs/187415087-list-users-by-ids.md
+++ b/changelogs/187415087-list-users-by-ids.md
@@ -1,0 +1,3 @@
+- [187415087](https://www.pivotaltracker.com/story/show/187415087) - List Users By Ids
+    - adds list_users_by_ids endpoint and client method
+

--- a/oxidauth-http/src/provider/mod.rs
+++ b/oxidauth-http/src/provider/mod.rs
@@ -78,6 +78,16 @@ pub async fn setup() -> Result<Provider, BoxedError> {
     }
 
     {
+        use oxidauth_kernel::users::find_users_by_ids::FindUsersByIdsService;
+        use oxidauth_usecases::users::find_users_by_ids::FindUsersByIdsUseCase;
+
+        let find_users_by_ids_service = Arc::new(FindUsersByIdsUseCase::new(
+            db.clone(),
+        ));
+        provider.store::<FindUsersByIdsService>(find_users_by_ids_service);
+    }
+
+    {
         use oxidauth_kernel::users::delete_user_by_id::DeleteUserByIdService;
         use oxidauth_usecases::users::delete_user_by_id::DeleteUserByIdUseCase;
 

--- a/oxidauth-http/src/server/api/v1/users/find_users_by_ids.rs
+++ b/oxidauth-http/src/server/api/v1/users/find_users_by_ids.rs
@@ -1,0 +1,75 @@
+use axum::{extract::State, response::IntoResponse, Json};
+use oxidauth_kernel::users::find_users_by_ids::*;
+use oxidauth_kernel::{error::IntoOxidAuthError, users::User};
+use oxidauth_permission::parse_and_validate_multiple;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::middleware::permission_extractor::{
+    ExtractEntitlements, ExtractJwt,
+};
+use crate::provider::Provider;
+use crate::response::Response;
+
+pub type FindUsersByIdsReq = FindUsersByIds;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FindUsersByIdsRes {
+    pub users: Vec<User>,
+    pub user_ids_not_found: Vec<Uuid>,
+}
+
+#[tracing::instrument(name = "find_users_by_ids_handler", skip(provider))]
+pub async fn handle(
+    State(provider): State<Provider>,
+    ExtractJwt(jwt): ExtractJwt,
+    ExtractEntitlements(permissions): ExtractEntitlements,
+    Json(params): Json<FindUsersByIdsReq>,
+) -> impl IntoResponse {
+    let challenges = vec!["oxidauth:users:manage".to_string()];
+
+    match parse_and_validate_multiple(&challenges, &permissions) {
+        Ok(true) => info!(
+            "{:?} has {:?}",
+            jwt.sub, challenges
+        ),
+        Ok(false) => {
+            warn!(
+                "{:?} doesn't have {:?}",
+                jwt.sub, challenges
+            );
+
+            return Response::unauthorized();
+        },
+        Err(err) => return Response::fail().error(err.to_string()),
+    }
+
+    let service = provider.fetch::<FindUsersByIdsService>();
+
+    info!("provided FindUsersByIdsService");
+
+    let result = service.call(&params).await;
+
+    match result {
+        Ok(res) => {
+            info!(
+                message = "successfully found users by ids",
+                res = ?res,
+            );
+
+            Response::success().payload(FindUsersByIdsRes {
+                users: res.0,
+                user_ids_not_found: res.1,
+            })
+        },
+        Err(err) => {
+            info!(
+                message = "failed to find users by ids",
+                err = ?err,
+            );
+
+            Response::fail().error(err.into_error())
+        },
+    }
+}

--- a/oxidauth-http/src/server/api/v1/users/mod.rs
+++ b/oxidauth-http/src/server/api/v1/users/mod.rs
@@ -6,6 +6,7 @@ pub mod create_user;
 pub mod delete_user_by_id;
 pub mod find_user_by_id;
 pub mod find_user_by_username;
+pub mod find_users_by_ids;
 pub mod list_all_users;
 pub mod update_user;
 
@@ -23,6 +24,10 @@ pub fn router() -> Router<Provider> {
         .route(
             "/",
             get(list_all_users::handle),
+        )
+        .route(
+            "/by_ids",
+            post(find_users_by_ids::handle),
         )
         .route("/", post(create_user::handle))
         .route(

--- a/oxidauth-kernel/src/users/find_users_by_ids.rs
+++ b/oxidauth-kernel/src/users/find_users_by_ids.rs
@@ -5,7 +5,7 @@ pub use super::User;
 pub type FindUsersByIdsService = Arc<
     dyn for<'a> Service<
         &'a FindUsersByIds,
-        Response = (Vec<User>, Vec<Uuid>),
+        Response = UsersByIds,
         Error = BoxedError,
     >,
 >;
@@ -13,4 +13,10 @@ pub type FindUsersByIdsService = Arc<
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FindUsersByIds {
     pub user_ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UsersByIds {
+    pub users: Vec<User>,
+    pub user_ids_not_found: Vec<Uuid>,
 }

--- a/oxidauth-kernel/src/users/find_users_by_ids.rs
+++ b/oxidauth-kernel/src/users/find_users_by_ids.rs
@@ -1,0 +1,16 @@
+use crate::dev_prelude::*;
+
+pub use super::User;
+
+pub type FindUsersByIdsService = Arc<
+    dyn for<'a> Service<
+        &'a FindUsersByIds,
+        Response = (Vec<User>, Vec<Uuid>),
+        Error = BoxedError,
+    >,
+>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FindUsersByIds {
+    pub user_ids: Vec<Uuid>,
+}

--- a/oxidauth-kernel/src/users/mod.rs
+++ b/oxidauth-kernel/src/users/mod.rs
@@ -2,6 +2,7 @@ pub mod create_user;
 pub mod delete_user_by_id;
 pub mod find_user_by_id;
 pub mod find_user_by_username;
+pub mod find_users_by_ids;
 pub mod list_all_users;
 pub mod update_user;
 

--- a/oxidauth-postgres/src/users/mod.rs
+++ b/oxidauth-postgres/src/users/mod.rs
@@ -10,9 +10,10 @@ pub mod insert_user;
 pub mod select_all_users_query;
 pub mod select_user_by_id_query;
 pub mod select_user_by_username_query;
+pub mod select_users_by_ids_query;
 pub mod update_user;
 
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct UserRow {
     pub id: Uuid,
     pub kind: String,

--- a/oxidauth-postgres/src/users/select_users_by_ids_query/mod.rs
+++ b/oxidauth-postgres/src/users/select_users_by_ids_query/mod.rs
@@ -1,3 +1,4 @@
+use oxidauth_kernel::users::{find_users_by_ids::UsersByIds, User};
 use oxidauth_repository::users::select_users_by_ids_query::*;
 use sqlx::PgConnection;
 
@@ -7,7 +8,7 @@ use super::{TryFromUserRowError, UserRow};
 
 #[async_trait]
 impl<'a> Service<&'a FindUsersByIds> for Database {
-    type Response = (Vec<User>, Vec<Uuid>);
+    type Response = UsersByIds;
     type Error = BoxedError;
 
     #[tracing::instrument(name = "select_users_by_ids_query", skip(self))]
@@ -38,7 +39,10 @@ impl<'a> Service<&'a FindUsersByIds> for Database {
             })
             .collect::<Result<Vec<User>, BoxedError>>()?;
 
-        Ok((users, user_ids_not_found))
+        Ok(UsersByIds {
+            users,
+            user_ids_not_found,
+        })
     }
 }
 

--- a/oxidauth-postgres/src/users/select_users_by_ids_query/mod.rs
+++ b/oxidauth-postgres/src/users/select_users_by_ids_query/mod.rs
@@ -1,0 +1,67 @@
+use oxidauth_repository::users::select_users_by_ids_query::*;
+use sqlx::PgConnection;
+
+use crate::prelude::*;
+
+use super::{TryFromUserRowError, UserRow};
+
+#[async_trait]
+impl<'a> Service<&'a FindUsersByIds> for Database {
+    type Response = (Vec<User>, Vec<Uuid>);
+    type Error = BoxedError;
+
+    #[tracing::instrument(name = "select_users_by_ids_query", skip(self))]
+    async fn call(
+        &self,
+        params: &'a FindUsersByIds,
+    ) -> Result<Self::Response, Self::Error> {
+        let mut conn = self.pool.acquire().await?;
+
+        let user_rows =
+            select_users_by_ids_query(&mut conn, &params.user_ids).await?;
+
+        let user_ids_found: Vec<Uuid> = user_rows
+            .clone()
+            .into_iter()
+            .map(|u| u.id)
+            .collect();
+
+        let mut user_ids_not_found = params.user_ids.clone();
+
+        user_ids_not_found.retain(|id| !&user_ids_found.contains(id));
+
+        let users = user_rows
+            .into_iter()
+            .map(|u| {
+                u.try_into()
+                    .map_err(|err: TryFromUserRowError| Box::new(err).into())
+            })
+            .collect::<Result<Vec<User>, BoxedError>>()?;
+
+        Ok((users, user_ids_not_found))
+    }
+}
+
+pub async fn select_users_by_ids_query(
+    conn: &mut PgConnection,
+    user_ids: &[Uuid],
+) -> Result<Vec<UserRow>, BoxedError> {
+    let result = sqlx::query_as::<_, UserRow>(include_str!(
+        "./select_users_by_ids_query.sql"
+    ))
+    .bind(user_ids)
+    .fetch_all(conn)
+    .await?;
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use sqlx::PgPool;
+
+    #[ignore]
+    #[sqlx::test]
+    async fn it_should_query_users_by_ids_successfully(_pool: PgPool) {}
+}

--- a/oxidauth-postgres/src/users/select_users_by_ids_query/select_users_by_ids_query.sql
+++ b/oxidauth-postgres/src/users/select_users_by_ids_query/select_users_by_ids_query.sql
@@ -1,3 +1,3 @@
 SELECT *
 FROM users
-WHERE id = ANY($1);
+WHERE id = ANY($1)

--- a/oxidauth-postgres/src/users/select_users_by_ids_query/select_users_by_ids_query.sql
+++ b/oxidauth-postgres/src/users/select_users_by_ids_query/select_users_by_ids_query.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM users
+WHERE id = ANY($1);

--- a/oxidauth-repository/src/users/mod.rs
+++ b/oxidauth-repository/src/users/mod.rs
@@ -3,6 +3,7 @@ pub mod insert_user;
 pub mod select_all_users_query;
 pub mod select_user_by_id_query;
 pub mod select_user_by_username_query;
+pub mod select_users_by_ids_query;
 pub mod update_user;
 
 pub use crate::prelude::*;

--- a/oxidauth-repository/src/users/select_users_by_ids_query.rs
+++ b/oxidauth-repository/src/users/select_users_by_ids_query.rs
@@ -1,21 +1,17 @@
 pub use oxidauth_kernel::users::find_users_by_ids::FindUsersByIds;
-pub use oxidauth_kernel::users::User;
+use oxidauth_kernel::users::find_users_by_ids::UsersByIds;
 
 use crate::prelude::*;
 
 pub trait SelectUsersByIdsQuery:
-    for<'a> Service<
-    &'a FindUsersByIds,
-    Response = (Vec<User>, Vec<Uuid>),
-    Error = BoxedError,
->
+    for<'a> Service<&'a FindUsersByIds, Response = UsersByIds, Error = BoxedError>
 {
 }
 
 impl<T> SelectUsersByIdsQuery for T where
     T: for<'a> Service<
         &'a FindUsersByIds,
-        Response = (Vec<User>, Vec<Uuid>),
+        Response = UsersByIds,
         Error = BoxedError,
     >
 {

--- a/oxidauth-repository/src/users/select_users_by_ids_query.rs
+++ b/oxidauth-repository/src/users/select_users_by_ids_query.rs
@@ -1,0 +1,22 @@
+pub use oxidauth_kernel::users::find_users_by_ids::FindUsersByIds;
+pub use oxidauth_kernel::users::User;
+
+use crate::prelude::*;
+
+pub trait SelectUsersByIdsQuery:
+    for<'a> Service<
+    &'a FindUsersByIds,
+    Response = (Vec<User>, Vec<Uuid>),
+    Error = BoxedError,
+>
+{
+}
+
+impl<T> SelectUsersByIdsQuery for T where
+    T: for<'a> Service<
+        &'a FindUsersByIds,
+        Response = (Vec<User>, Vec<Uuid>),
+        Error = BoxedError,
+    >
+{
+}

--- a/oxidauth-rs/src/client/users/find_users_by_ids.rs
+++ b/oxidauth-rs/src/client/users/find_users_by_ids.rs
@@ -1,0 +1,31 @@
+use oxidauth_http::response::Response;
+pub use oxidauth_http::server::api::v1::users::find_users_by_ids::{
+    FindUsersByIdsReq, FindUsersByIdsRes,
+};
+use oxidauth_kernel::error::BoxedError;
+
+use super::*;
+
+const RESOURCE: Resource = Resource::User;
+const METHOD: &str = "find_users_by_ids";
+
+impl Client {
+    #[tracing::instrument(skip(self))]
+    pub async fn find_users_by_ids<T>(
+        &self,
+        params: T,
+    ) -> Result<FindUsersByIdsRes, BoxedError>
+    where
+        T: Into<FindUsersByIdsReq> + fmt::Debug,
+    {
+        let params = params.into();
+
+        let resp: Response<FindUsersByIdsRes> = self
+            .post("/users", Some(params))
+            .await?;
+
+        let users_res = handle_response(RESOURCE, METHOD, resp)?;
+
+        Ok(users_res)
+    }
+}

--- a/oxidauth-rs/src/client/users/mod.rs
+++ b/oxidauth-rs/src/client/users/mod.rs
@@ -3,6 +3,7 @@ pub mod create_user;
 pub mod delete_user;
 pub mod find_user_by_id;
 pub mod find_user_by_username;
+pub mod find_users_by_ids;
 pub mod list_all_users;
 pub mod permissions;
 pub mod roles;

--- a/oxidauth-usecases/src/users/find_users_by_ids.rs
+++ b/oxidauth-usecases/src/users/find_users_by_ids.rs
@@ -1,0 +1,40 @@
+use async_trait::async_trait;
+
+use oxidauth_kernel::{
+    error::BoxedError, service::Service, users::find_users_by_ids::*,
+};
+use oxidauth_repository::users::select_users_by_ids_query::SelectUsersByIdsQuery;
+use uuid::Uuid;
+
+pub struct FindUsersByIdsUseCase<T>
+where
+    T: SelectUsersByIdsQuery,
+{
+    users: T,
+}
+
+impl<T> FindUsersByIdsUseCase<T>
+where
+    T: SelectUsersByIdsQuery,
+{
+    pub fn new(users: T) -> Self {
+        Self { users }
+    }
+}
+
+#[async_trait]
+impl<'a, T> Service<&'a FindUsersByIds> for FindUsersByIdsUseCase<T>
+where
+    T: SelectUsersByIdsQuery,
+{
+    type Response = (Vec<User>, Vec<Uuid>);
+    type Error = BoxedError;
+
+    #[tracing::instrument(name = "find_users_by_ids_usecase", skip(self))]
+    async fn call(
+        &self,
+        req: &'a FindUsersByIds,
+    ) -> Result<Self::Response, Self::Error> {
+        self.users.call(req).await
+    }
+}

--- a/oxidauth-usecases/src/users/find_users_by_ids.rs
+++ b/oxidauth-usecases/src/users/find_users_by_ids.rs
@@ -4,7 +4,6 @@ use oxidauth_kernel::{
     error::BoxedError, service::Service, users::find_users_by_ids::*,
 };
 use oxidauth_repository::users::select_users_by_ids_query::SelectUsersByIdsQuery;
-use uuid::Uuid;
 
 pub struct FindUsersByIdsUseCase<T>
 where
@@ -27,7 +26,7 @@ impl<'a, T> Service<&'a FindUsersByIds> for FindUsersByIdsUseCase<T>
 where
     T: SelectUsersByIdsQuery,
 {
-    type Response = (Vec<User>, Vec<Uuid>);
+    type Response = UsersByIds;
     type Error = BoxedError;
 
     #[tracing::instrument(name = "find_users_by_ids_usecase", skip(self))]

--- a/oxidauth-usecases/src/users/mod.rs
+++ b/oxidauth-usecases/src/users/mod.rs
@@ -2,5 +2,6 @@ pub mod create_user;
 pub mod delete_user_by_id;
 pub mod find_user_by_id;
 pub mod find_user_by_username;
+pub mod find_users_by_ids;
 pub mod list_all_users;
 pub mod update_user;


### PR DESCRIPTION
Ticket: [187415087](https://www.pivotaltracker.com/story/show/187415087)

# Summary

- Adds endpoint and client method for listing users by an array of user_ids. The endpoint should return both all of the users found as well as any ids that we could not find users for. 

# Testing Instructions
- spin up containers
- ` curl -X POST -H 'Content-Type: application/json' --data '{ "refresh_token": "{LOCAL_REFRESH_TOKEN_ID}" }' http://api.oxidauth.localhost/api/v1/refresh_tokens` to get a `JWT`
- `curl -X POST http://api.oxidauth.localhost/api/v1/users/by_ids -H "Authorization: Bearer {JWT}" -H 'Content-Type: application/json' --data '{"user_ids": ["{LOCAL_USER_ID}", "{NONEXISTENT_USER_ID}"]}'`
  - make sure to add a local user_id or two but also add at least one id that is not present in the db
- confirm the expected users are found and any ids not in your local db are appropriately returned