### PR TITLE
role by role name client fix

### DIFF
--- a/oxidauth-rs/src/client/roles/find_role_by_name.rs
+++ b/oxidauth-rs/src/client/roles/find_role_by_name.rs
@@ -20,7 +20,7 @@ impl Client {
 
         let resp: Response<FindRoleByNameRes> = self
             .get(
-                &format!("/roles/{}", role),
+                &format!("/roles/by_name/{}", role),
                 None::<()>,
             )
             .await?;


### PR DESCRIPTION
# Summary

- fixes bad url on the oxidauth client for fetching the role by the role name
