### PR TITLE
Optional email argument to oAuth redirect 

### DIFF
--- a/oxidauth-kernel/src/auth/oauth2/redirect.rs
+++ b/oxidauth-kernel/src/auth/oauth2/redirect.rs
@@ -17,7 +17,7 @@ pub type Oauth2RedirectService = Arc<
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Oauth2RedirectParams {
     pub client_key: Uuid,
-    pub email: String,
+    pub email: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -35,11 +35,7 @@ impl fmt::Display for ParseOauth2RedirectUrlError {
         use ParseOauth2RedirectUrlError::*;
 
         match self {
-            Unknown(value) => write!(
-                f,
-                "unable to create redirect_url: {}",
-                value
-            ),
+            Unknown(value) => write!(f, "unable to create redirect_url: {}", value),
         }
     }
 }

--- a/oxidauth-usecases/src/auth/strategies/oauth2/redirect.rs
+++ b/oxidauth-usecases/src/auth/strategies/oauth2/redirect.rs
@@ -81,10 +81,10 @@ where
                     .append_pair("state", state_hash.as_str())
                     .finish();
 
-                if let Some(email) = params.email.clone() {
+                if let Some(email) = &params.email {
                     combined_redirect_url
                         .query_pairs_mut()
-                        .append_pair("login_hint", &email)
+                        .append_pair("login_hint", email)
                         .finish();
                 };
 

--- a/oxidauth-usecases/src/auth/strategies/oauth2/redirect.rs
+++ b/oxidauth-usecases/src/auth/strategies/oauth2/redirect.rs
@@ -62,28 +62,33 @@ where
             OAuthFlavors::Google => {
                 let mut redirect_url = oauth_params.redirect_url;
 
-                let redirect_url = redirect_url
+                let combined_redirect_url = redirect_url
                     .query_pairs_mut()
-                    .append_pair("login_hint", &params.email)
                     .append_pair("response_type", "code")
                     .append_pair("include_granted_scopes", "true")
                     .append_pair("state", state_hash.as_str())
                     .finish();
 
-                redirect_url.to_owned()
+                combined_redirect_url.to_owned()
             },
             OAuthFlavors::Microsoft => {
                 let mut redirect_url = oauth_params.redirect_url;
 
-                let redirect_url = redirect_url
+                let combined_redirect_url = redirect_url
                     .query_pairs_mut()
-                    .append_pair("login_hint", &params.email)
                     .append_pair("response_type", "code")
                     .append_pair("response_mode", "query")
                     .append_pair("state", state_hash.as_str())
                     .finish();
 
-                redirect_url.to_owned()
+                if let Some(email) = params.email.clone() {
+                    combined_redirect_url
+                        .query_pairs_mut()
+                        .append_pair("login_hint", &email)
+                        .finish();
+                };
+
+                combined_redirect_url.to_owned()
             },
         };
 


### PR DESCRIPTION
# Summary

- Email used to be a required argument, but it was only used to generate a hint which not all product users will want to do. Better design to optionally include the hint if the email value is passed. 

NOTE: This is a breaking change that affects the argument structure of oAuth requests because of the argument type going from String to Option<String>
