### PR TITLE
optional profile information was coded as string instead of option

### DIFF
--- a/oxidauth-http/src/server/api/v1/auth/oauth2/callback.rs
+++ b/oxidauth-http/src/server/api/v1/auth/oauth2/callback.rs
@@ -108,7 +108,7 @@ fn gen_redirect_url(
     email: String,
     given_name: Option<String>,
     family_name: Option<String>,
-    user_id: String,
+    user_id: Uuid,
 ) -> Result<Url, url::ParseError> {
     let mut path = format!(
         "/auth/sso/login/{}?email={}&user_id={}",

--- a/oxidauth-http/src/server/api/v1/auth/oauth2/callback.rs
+++ b/oxidauth-http/src/server/api/v1/auth/oauth2/callback.rs
@@ -106,14 +106,22 @@ fn gen_redirect_url(
     base: Url,
     refresh_token: Uuid,
     email: String,
-    given_name: String,
-    family_name: String,
-    user_id: Uuid,
+    given_name: Option<String>,
+    family_name: Option<String>,
+    user_id: String,
 ) -> Result<Url, url::ParseError> {
-    let path = format!(
-        "/auth/sso/login/{}?email={}&given_name={}&family_name={}&user_id={}",
-        refresh_token, email, given_name, family_name, user_id,
+    let mut path = format!(
+        "/auth/sso/login/{}?email={}&user_id={}",
+        refresh_token, email, user_id,
     );
+
+    if let Some(given_name) = given_name {
+        path = format!("{}&given_name={}", path, given_name)
+    }
+
+    if let Some(family_name) = family_name {
+        path = format!("{}&family_name={}", path, family_name)
+    }
 
     base.join(&path)
 }

--- a/oxidauth-http/src/server/api/v1/auth/oauth2/callback.rs
+++ b/oxidauth-http/src/server/api/v1/auth/oauth2/callback.rs
@@ -110,18 +110,36 @@ fn gen_redirect_url(
     family_name: Option<String>,
     user_id: Uuid,
 ) -> Result<Url, url::ParseError> {
-    let mut path = format!(
-        "/auth/sso/login/{}?email={}&user_id={}",
-        refresh_token, email, user_id,
-    );
+    // let mut path = format!(
+    //     "/auth/sso/login/{}?email={}&user_id={}",
+    //     refresh_token, email, user_id,
+    // );
+
+    // if let Some(given_name) = given_name {
+    //     path = format!("{}&given_name={}", path, given_name)
+    // }
+
+    // if let Some(family_name) = family_name {
+    //     path = format!("{}&family_name={}", path, family_name)
+    // }
+
+    // base.join(&path)
+
+    let mut url = base.join(&format!("/auth/sso/login/{}", refresh_token))?;
+
+    url.query_pairs_mut()
+        .append_pair("email", &email)
+        .append_pair("user_id", &user_id.to_string());
 
     if let Some(given_name) = given_name {
-        path = format!("{}&given_name={}", path, given_name)
+        url.query_pairs_mut()
+            .append_pair("given_name", &given_name);
     }
 
     if let Some(family_name) = family_name {
-        path = format!("{}&family_name={}", path, family_name)
+        url.query_pairs_mut()
+            .append_pair("family_name", &family_name);
     }
 
-    base.join(&path)
+    Ok(url)
 }

--- a/oxidauth-kernel/src/auth/authenticate_or_register.rs
+++ b/oxidauth-kernel/src/auth/authenticate_or_register.rs
@@ -26,7 +26,7 @@ pub struct AuthenticateOrRegisterResponse {
     pub email: String,
     pub given_name: Option<String>,
     pub family_name: Option<String>,
-    pub user_id: String,
+    pub user_id: Uuid,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/oxidauth-kernel/src/auth/authenticate_or_register.rs
+++ b/oxidauth-kernel/src/auth/authenticate_or_register.rs
@@ -24,9 +24,9 @@ pub struct AuthenticateOrRegisterResponse {
     pub refresh_token: Uuid,
     pub client_base: Url,
     pub email: String,
-    pub given_name: String,
-    pub family_name: String,
-    pub user_id: Uuid,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub user_id: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -81,6 +81,6 @@ pub struct OAuth2AuthenticatePathParams {
 #[derive(Debug, Clone, Deserialize)]
 pub struct OAuth2Profile {
     pub email: String,
-    pub given_name: String,
-    pub family_name: String,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
 }

--- a/oxidauth-usecases/src/auth/authenticate_or_register.rs
+++ b/oxidauth-usecases/src/auth/authenticate_or_register.rs
@@ -193,7 +193,7 @@ where
                     email: profile.email.clone(),
                     given_name: profile.given_name.clone(),
                     family_name: profile.family_name.clone(),
-                    user_id: auth.user_id.to_string(),
+                    user_id: auth.user_id,
                 });
             },
             Err(err) => {
@@ -226,7 +226,7 @@ where
                         email: profile.email.clone(),
                         given_name: profile.given_name,
                         family_name: profile.family_name,
-                        user_id: result.user_id.to_string(),
+                        user_id: result.user_id,
                     };
 
                     return Ok(res);

--- a/oxidauth-usecases/src/auth/authenticate_or_register.rs
+++ b/oxidauth-usecases/src/auth/authenticate_or_register.rs
@@ -193,7 +193,7 @@ where
                     email: profile.email.clone(),
                     given_name: profile.given_name.clone(),
                     family_name: profile.family_name.clone(),
-                    user_id: auth.user_id,
+                    user_id: auth.user_id.to_string(),
                 });
             },
             Err(err) => {
@@ -202,8 +202,8 @@ where
                     .contains("user authority not found:")
                 {
                     let reg_params = Oauth2RegisterParams {
-                        first_name: Some(profile.given_name.clone()),
-                        last_name: Some(profile.family_name.clone()),
+                        first_name: profile.given_name.clone(),
+                        last_name: profile.family_name.clone(),
                         email: Some(profile.email.clone()),
                         username: profile.email.clone(),
                         kind: Some(UserKind::Human),
@@ -226,7 +226,7 @@ where
                         email: profile.email.clone(),
                         given_name: profile.given_name,
                         family_name: profile.family_name,
-                        user_id: result.user_id,
+                        user_id: result.user_id.to_string(),
                     };
 
                     return Ok(res);

--- a/oxidauth-usecases/src/auth/strategies/oauth2/google/mod.rs
+++ b/oxidauth-usecases/src/auth/strategies/oauth2/google/mod.rs
@@ -28,11 +28,11 @@ pub struct GoogleExchangeTokenRes {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GoogleProfile {
-    pub name: String,
-    pub given_name: String,
-    pub family_name: String,
-    pub picture: String,
-    pub id: String,
+    pub name: Option<String>,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub picture: Option<String>,
+    pub id: Option<String>,
     pub email: String,
     pub verified_email: bool,
 }

--- a/oxidauth-usecases/src/auth/strategies/oauth2/microsoft/mod.rs
+++ b/oxidauth-usecases/src/auth/strategies/oauth2/microsoft/mod.rs
@@ -31,9 +31,9 @@ pub struct MicrosoftExchangeTokenRes {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MicrosoftProfile {
-    pub display_name: String,
-    pub given_name: String,
-    pub surname: String,
+    pub display_name: Option<String>,
+    pub given_name: Option<String>,
+    pub surname: Option<String>,
     pub id: String,
     pub mail: String,
 }


### PR DESCRIPTION
The previous implementation of oauth accidentally assumed the inclusion of the "profile" scope by including given and family name as String instead of Option. When the profile scope is not requested, these fields are not available in both google and microsoft oauth.
